### PR TITLE
Unit Test

### DIFF
--- a/alloyextension/pom.xml
+++ b/alloyextension/pom.xml
@@ -13,30 +13,17 @@
 	<name>Alloy Analyzer Terminal Extension</name>
 
 
-
-	<dependencies>
-
-
-		<dependency>
-			<groupId>commons-cli</groupId>
-			<artifactId>commons-cli</artifactId>
-			<version>1.2</version>
-		</dependency>
-
-
-
-	</dependencies>
-
-
-	<repositories>
-		<repository>
-			<id>overture.au.dk-mirror-external</id>
-			<name>Mirror of external dependencies at Project Build Repository at AU</name>
-			<url>http://overture.au.dk/maven/mirror-external-m2repo/</url>
-			<layout>default</layout>
-		</repository>
-
-	</repositories>
-
+    <dependencies>
+        <dependency>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
+            <version>1.2</version>
+        </dependency>
+        <dependency>
+            <groupId>mit.edu</groupId>
+            <artifactId>alloy</artifactId>
+            <version>4.2</version>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,8 @@
 	<parent>
 		<groupId>org.overturetool</groupId>
 		<artifactId>core</artifactId>
-		<version>2.2.3-SNAPSHOT<!--Replaceable: Main Version--></version>
-		<relativePath>../PI_MFES/pom.xml</relativePath>
+        <version>2.2.3-SNAPSHOT<!--Replaceable: Main Version--></version>
+        <relativePath></relativePath> <!-- Fetch parent from repositories -->
 	</parent>
 
 	<packaging>pom</packaging>
@@ -17,17 +17,21 @@
 		<module>alloyextension</module>
 		<module>vdm2alloy</module>
 	</modules>
-
-
-
-
+    
 	<repositories>
 		<repository>
 			<id>overture.au.dk-mirror-external</id>
 			<name>Mirror of external dependencies at Project Build Repository at AU</name>
 			<url>http://overture.au.dk/maven/mirror-external-m2repo/</url>
 			<layout>default</layout>
-		</repository>
+        </repository>
+
+        <repository>
+            <id>sonatype-snapshot</id>
+            <name>Sonatype Snapshots Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <layout>default</layout>
+        </repository>
 
 	</repositories>
 

--- a/vdm2alloy/pom.xml
+++ b/vdm2alloy/pom.xml
@@ -1,39 +1,46 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
-     <groupId>org.overturetool.core</groupId>
-  <artifactId>alloy</artifactId>
-    <version>2.2.3-SNAPSHOT<!--Replaceable: Main Version--></version>
-    <relativePath>../vdm2alloy/pom.xml</relativePath>
-  </parent>
+	<parent>
+		<groupId>org.overturetool.core</groupId>
+		<artifactId>alloy</artifactId>
+		<version>2.2.3-SNAPSHOT<!--Replaceable: Main Version--></version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
 
- <groupId>org.overturetool.core.alloy</groupId>
-  <artifactId>vdm2alloy</artifactId>
-  <name>VDM-SL to Alloy Translation</name>
-  
-  <dependencies>
-      <dependency>
-          <groupId>org.overturetool.core.alloy</groupId>
-          <artifactId>alloyextension</artifactId>
-          <version>${project.version}</version>
-      </dependency>
-      <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.11</version>
-      </dependency>
-      <dependency>
-          <groupId>org.overturetool.core</groupId>
-          <artifactId>ast</artifactId>
-          <version>2.2.2</version>
-      </dependency>
-      <dependency>
-          <groupId>org.overturetool.core</groupId>
-          <artifactId>typechecker</artifactId>
-          <version>2.2.2</version>
-      </dependency>
-</dependencies>
+	<groupId>org.overturetool.core.alloy</groupId>
+	<artifactId>vdm2alloy</artifactId>
+	<name>VDM-SL to Alloy Translation</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.overturetool.core.alloy</groupId>
+			<artifactId>alloyextension</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+		</dependency>
+		<dependency>
+			<groupId>org.overturetool.core</groupId>
+			<artifactId>ast</artifactId>
+			<version>2.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.overturetool.core</groupId>
+			<artifactId>typechecker</artifactId>
+			<version>2.2.2</version>
+		</dependency>
+		<dependency>
+			<groupId>org.overturetool.core.testing</groupId>
+			<artifactId>framework</artifactId>
+			<version>2.2.3-SNAPSHOT</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 
 </project>

--- a/vdm2alloy/src/test/java/org/overturetool/alloy/test/unit/Vdm2AlloyUnitTest.java
+++ b/vdm2alloy/src/test/java/org/overturetool/alloy/test/unit/Vdm2AlloyUnitTest.java
@@ -1,0 +1,93 @@
+package org.overturetool.alloy.test.unit;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.overture.alloy.Alloy2VdmAnalysis;
+import org.overture.alloy.Context;
+import org.overture.alloy.ast.Part;
+import org.overture.ast.analysis.AnalysisException;
+import org.overture.ast.node.INode;
+import org.overture.core.tests.ParamStandardTest;
+import org.overture.core.tests.PathsProvider;
+
+import com.google.gson.reflect.TypeToken;
+
+@RunWith(Parameterized.class)
+public class Vdm2AlloyUnitTest extends ParamStandardTest<String>
+{
+
+
+	// Root location of the test input and result files
+	private static final String EXAMPLE_TEST_FILES = "src/test/resources/unit";
+
+	// The update property for this test
+	private static final String UPDATE_PROPERTY = "tests.update.alloy.Unit";
+
+	
+	public Vdm2AlloyUnitTest(String nameParameter, String inputParameter,
+			String resultParameter)
+	{
+		super(nameParameter, inputParameter, resultParameter);
+	}
+	
+	@Parameters(name = "{index} : {0}")
+	public static Collection<Object[]> testData()
+	{
+		return PathsProvider.computePaths(EXAMPLE_TEST_FILES);
+	}
+
+	@Override
+	public String processModel(List<INode> ast)
+	{
+		Alloy2VdmAnalysis analysis = new Alloy2VdmAnalysis(testName);
+		try
+		{
+			ast.get(0).apply(analysis, new Context());
+		} catch (AnalysisException e)
+		{
+			fail("Could not process test file " + testName);
+		}
+		return parts2String(analysis.components);
+	}
+
+	//TODO: Implement more intelligent comparison logic
+	@Override
+	public void compareResults(String actual, String expected)
+	{
+		assertEquals(expected,actual);
+	}
+	
+	@Override
+	public Type getResultType()
+	{
+		Type resultType = new TypeToken<String>()
+		{
+		}.getType();
+		return resultType;
+	}
+
+	@Override
+	protected String getUpdatePropertyString()
+	{
+		return UPDATE_PROPERTY;
+	}
+
+
+	private String parts2String(List<Part> parts){
+		StringBuilder sb = new StringBuilder();
+		for (Part p : parts){
+			sb.append(p.toString());
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
+
+}

--- a/vdm2alloy/src/test/resources/unit/typenat.vdmsl
+++ b/vdm2alloy/src/test/resources/unit/typenat.vdmsl
@@ -1,0 +1,2 @@
+types
+A = nat

--- a/vdm2alloy/src/test/resources/unit/typenat.vdmsl.result
+++ b/vdm2alloy/src/test/resources/unit/typenat.vdmsl.result
@@ -1,0 +1,1 @@
+"module typenat.vdmsl\n\nopen util/relation\nopen vdmutil\n\n/************************   A   ************************/\nsig nat in univ{}\nfact factNat{\n{ nat \u003d { i:Int | gte[i,0]}}\n}\n\nsig A in univ{}\nfact AType{\nA \u003d { y : nat}\n}\n\n"


### PR DESCRIPTION
Cá está o teste unitário que discutimos (também corrigi os poms que estavam com umas asneiras).

O test é `org.overturetool.alloy.test.unit.Vdm2AlloyUnitTest`. É um teste parametrizado por isso basta-vos adicionar mais inputs em `src/test/resources/unit` (pus lá um exemplo) e ele vai gerando um teste para cada um deles.

A comparação de resultados (em `compareResults`) está muito básica. Toma a tradução inteira como uma String e testa igualdade de strings. Deixo para vocês a implementação de algo mais sofisiticado, se acharem preciso.

Os resultados são armazenados em JSON (com o mesmo nome do input e o prefixo `.result`). Podem tentar escrever resultados à mão mas não aconselho. A maneira mais fácil é correr o teste em modo update que grava o resultado. Para fazer isso há duas possibilidades:
- correr o com o argumento à VM `-Dtests.update.alloy.Unit.<nomedotest>`. O nome de cada test é o nome do ficheiro input respectivo (incluindo extensão).
- no construtor do teste, colocar a variavel `updateResult` a `true`. Esta versão faz update a todos os resultados.
